### PR TITLE
Update Python 3.13 install dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ Flask-Login
 Flask-SQLAlchemy
 Flask-WTF
 greenlet
+legacy-cgi
 htmlmin
 idna
 importlib-metadata
@@ -18,7 +19,6 @@ Jinja2
 MarkupSafe
 mccabe
 mysqlclient
-pkg-resources
 pycodestyle
 pyflakes
 six

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -117,7 +117,7 @@ case $OS in
     fi
     
     printf "[+] I am installing required packages... "
-    if ! sudo apt -y install git python3-dev python3-virtualenv build-essential default-libmysqlclient-dev &> /dev/null; then
+    if ! sudo apt -y install git python3-dev python3-virtualenv build-essential default-libmysqlclient-dev pkg-config &> /dev/null; then
       echo "KO"
       echo "[!] Error when downloading/installing required packages."
       return 1


### PR DESCRIPTION
## Summary

- add `legacy-cgi` before `htmlmin` in `requirements.txt` for Python 3.13
- remove the stale `pkg-resources` requirement entry
- install `pkg-config` with the Debian/Ubuntu system packages used by `setup/install.sh`

Fixes #3.

## Validation

- Not run locally
